### PR TITLE
Add support for popUntil action.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ ios/Runner/GeneratedPluginRegistrant.*
 
 lib/generated/
 res/values/
+
+# Ignore VS Code settings files
+.vscode/

--- a/lib/src/navigate_to_action.dart
+++ b/lib/src/navigate_to_action.dart
@@ -13,6 +13,9 @@ enum NavigationType {
 
   /// The [Navigator.pushNamedAndRemoveUntil] will be called.
   shouldPushNamedAndRemoveUntil,
+
+  /// The [Navigator.popUntil] will be called
+  shouldPopUntil
 }
 
 /// The action to be dispatched in the store in order to trigger a navigation.
@@ -38,6 +41,7 @@ class NavigateToAction {
   final Object arguments;
 
   /// Optional object to be passed either in [NavigationType.shouldPushNamedAndRemoveUntil]
+  /// or in [NavigationType.shouldPopUntil]
   ///
   /// It will be ignored if passed with any other type.
   final RoutePredicate predicate;
@@ -54,6 +58,9 @@ class NavigateToAction {
       this.predicate})
       : assert(() {
           if (type == NavigationType.shouldPushNamedAndRemoveUntil) {
+            return predicate != null;
+          }
+          if (type == NavigationType.shouldPopUntil) {
             return predicate != null;
           }
           if (type != NavigationType.shouldPop) {
@@ -77,6 +84,16 @@ class NavigateToAction {
           type: NavigationType.shouldPop,
           preNavigation: preNavigation,
           postNavigation: postNavigation);
+
+  factory NavigateToAction.popUntil(
+          {Function preNavigation,
+          Function postNavigation,
+          RoutePredicate predicate}) =>
+      NavigateToAction(null,
+          type: NavigationType.shouldPopUntil,
+          preNavigation: preNavigation,
+          postNavigation: postNavigation,
+          predicate: predicate);
 
   factory NavigateToAction.replace(String name,
           {Function preNavigation,

--- a/lib/src/navigation_middleware.dart
+++ b/lib/src/navigation_middleware.dart
@@ -8,7 +8,7 @@ import 'package:redux/redux.dart';
 /// the navigation on the `currentState` of [NavigatorHolder.navigatorKey].
 ///
 /// It can perform either a `replace`, a `push`, a `pushNamedAndRemoveUntil`
-/// or a `pop` navigation action.
+/// a `pop`, or a `popUntil` navigation action.
 /// Prerequisite is to have register the appropriate navigation paths in
 /// `onGenerateRoute` method passed to [MaterialApp].
 class NavigationMiddleware<T> implements MiddlewareClass<T> {
@@ -36,6 +36,10 @@ class NavigationMiddleware<T> implements MiddlewareClass<T> {
         case NavigationType.shouldPop:
           currentState.pop();
           this._setState(NavigatorHolder.state?.previousPath);
+          break;
+        case NavigationType.shouldPopUntil:
+          currentState.popUntil(navigationAction.predicate);
+          this._setState(null);
           break;
         case NavigationType.shouldPushNamedAndRemoveUntil:
           currentState.pushNamedAndRemoveUntil(

--- a/test/src/navigate_to_action_test.dart
+++ b/test/src/navigate_to_action_test.dart
@@ -8,6 +8,12 @@ void main() {
     expect(action.name, isNull);
   });
 
+  test('should pass the NavigationType.shouldPopUntil and no route name', () {
+    var action = NavigateToAction.popUntil(predicate: (_) => false);
+    expect(action.type, NavigationType.shouldPopUntil);
+    expect(action.name, isNull);
+  });
+
   test('should pass the NavigationType.shouldReplace and route name', () {
     var action = NavigateToAction.replace('name');
     expect(action.type, NavigationType.shouldReplace);
@@ -26,42 +32,61 @@ void main() {
   });
 
   test(
-    'should throw AssertionError if the route name is null or empty on NavigationType.shouldPush',
+      'should throw AssertionError if the route name is null or empty on NavigationType.shouldPush',
       () {
-      expect(() => NavigateToAction(null), throwsAssertionError);
-      expect(() => NavigateToAction(''), throwsAssertionError);
-    });
+    expect(() => NavigateToAction(null), throwsAssertionError);
+    expect(() => NavigateToAction(''), throwsAssertionError);
+  });
 
   test(
-    'should throw AssertionError if the route name is null or empty on NavigationType.shouldReplace',
+      'should throw AssertionError if the route name is null or empty on NavigationType.shouldReplace',
       () {
-      expect(() => NavigateToAction(null, type: NavigationType.shouldReplace),
+    expect(() => NavigateToAction(null, type: NavigationType.shouldReplace),
         throwsAssertionError);
-      expect(() => NavigateToAction('', type: NavigationType.shouldReplace),
+    expect(() => NavigateToAction('', type: NavigationType.shouldReplace),
         throwsAssertionError);
-    });
+  });
 
   test('should allow null or empty route name on NavigationType.shouldPop', () {
     expect(() => NavigateToAction(null, type: NavigationType.shouldPop),
-      isNotNull);
+        isNotNull);
     expect(
         () => NavigateToAction('', type: NavigationType.shouldPop), isNotNull);
   });
 
-  test(
-    'should throw AssertionError if the route name is null or empty or predicate is null on NavigationType.pushNamedAndRemoveUntil',
+  test('should allow null or empty route name on NavigationType.shouldPopUntil',
       () {
-      expect(() =>
-        NavigateToAction(
-          null, type: NavigationType.shouldPushNamedAndRemoveUntil),
+    expect(
+        () => NavigateToAction(null,
+            type: NavigationType.shouldPopUntil, predicate: (_) => false),
+        isNotNull);
+    expect(
+        () => NavigateToAction('',
+            type: NavigationType.shouldPopUntil, predicate: (_) => false),
+        isNotNull);
+  });
+
+  test(
+      'should throw AssertionError if the route name is null or empty or predicate is null on NavigationType.pushNamedAndRemoveUntil',
+      () {
+    expect(
+        () => NavigateToAction(null,
+            type: NavigationType.shouldPushNamedAndRemoveUntil),
         throwsAssertionError);
-      expect(() =>
-        NavigateToAction(
-          '', type: NavigationType.shouldPushNamedAndRemoveUntil),
+    expect(
+        () => NavigateToAction('',
+            type: NavigationType.shouldPushNamedAndRemoveUntil),
         throwsAssertionError);
-      expect(() =>
-        NavigateToAction(
-          'name', type: NavigationType.shouldPushNamedAndRemoveUntil),
+    expect(
+        () => NavigateToAction('name',
+            type: NavigationType.shouldPushNamedAndRemoveUntil),
         throwsAssertionError);
-    });
+  });
+
+  test(
+      'should throw AssertionError if the predicate is null on NavigationType.popUntil',
+      () {
+    expect(() => NavigateToAction(null, type: NavigationType.shouldPopUntil),
+        throwsAssertionError);
+  });
 }

--- a/test/src/navigation_middleware_test.dart
+++ b/test/src/navigation_middleware_test.dart
@@ -40,10 +40,11 @@ void main() {
       final navigatorState = MockNavigatorState();
 
       NavigationMiddleware(currentState: navigatorState)
-        .call(store, NavigateToAction.push('/name'), (_) {});
+          .call(store, NavigateToAction.push('/name'), (_) {});
 
       verifyNever(navigatorState.pushReplacementNamed(any));
       verifyNever(navigatorState.pop());
+      verifyNever(navigatorState.popUntil(any));
       verifyNever(navigatorState.pushNamedAndRemoveUntil(any, any));
       verify(navigatorState.pushNamed('/name'));
     });
@@ -54,10 +55,11 @@ void main() {
       final arguments = {};
 
       NavigationMiddleware(currentState: navigatorState).call(
-        store, NavigateToAction.push('/name', arguments: arguments), (_) {});
+          store, NavigateToAction.push('/name', arguments: arguments), (_) {});
 
       verifyNever(navigatorState.pushReplacementNamed(any));
       verifyNever(navigatorState.pop());
+      verifyNever(navigatorState.popUntil(any));
       verifyNever(navigatorState.pushNamedAndRemoveUntil(any, any));
       verify(navigatorState.pushNamed('/name', arguments: arguments));
     });
@@ -67,10 +69,11 @@ void main() {
       final navigatorState = MockNavigatorState();
 
       NavigationMiddleware(currentState: navigatorState)
-        .call(store, NavigateToAction.replace('/name'), (_) {});
+          .call(store, NavigateToAction.replace('/name'), (_) {});
 
       verifyNever(navigatorState.pushNamed(any));
       verifyNever(navigatorState.pop());
+      verifyNever(navigatorState.popUntil(any));
       verifyNever(navigatorState.pushNamedAndRemoveUntil(any, any));
       verify(navigatorState.pushReplacementNamed('/name'));
     });
@@ -81,13 +84,14 @@ void main() {
       final arguments = {};
 
       NavigationMiddleware(currentState: navigatorState).call(store,
-        NavigateToAction.replace('/name', arguments: arguments), (_) {});
+          NavigateToAction.replace('/name', arguments: arguments), (_) {});
 
       verifyNever(navigatorState.pushNamed(any));
       verifyNever(navigatorState.pop());
+      verifyNever(navigatorState.popUntil(any));
       verifyNever(navigatorState.pushNamedAndRemoveUntil(any, any));
       verify(
-        navigatorState.pushReplacementNamed('/name', arguments: arguments));
+          navigatorState.pushReplacementNamed('/name', arguments: arguments));
     });
 
     test('should call pop on currentState', () {
@@ -95,9 +99,10 @@ void main() {
       final navigatorState = MockNavigatorState();
 
       NavigationMiddleware(currentState: navigatorState)
-        .call(store, NavigateToAction.pop(), (_) {});
+          .call(store, NavigateToAction.pop(), (_) {});
 
       verifyNever(navigatorState.pushNamed(any));
+      verifyNever(navigatorState.popUntil(any));
       verifyNever(navigatorState.pushReplacementNamed(any));
       verifyNever(navigatorState.pushNamedAndRemoveUntil(any, any));
       verify(navigatorState.pop());
@@ -108,9 +113,10 @@ void main() {
       final navigatorState = MockNavigatorState();
 
       NavigationMiddleware(currentState: navigatorState)
-        .call(store, NavigateToAction.pop(), (_) {});
+          .call(store, NavigateToAction.pop(), (_) {});
 
       verifyNever(navigatorState.pushNamed(any));
+      verifyNever(navigatorState.popUntil(any));
       verifyNever(navigatorState.pushReplacementNamed(any));
       verifyNever(navigatorState.pushNamedAndRemoveUntil(any, any));
       verify(navigatorState.pop());
@@ -121,15 +127,29 @@ void main() {
       final navigatorState = MockNavigatorState();
       final predicate = (Route<dynamic> route) => false;
 
-      NavigationMiddleware(currentState: navigatorState)
-        .call(
-        store, NavigateToAction.pushNamedAndRemoveUntil('name', predicate),
-          (_) {});
+      NavigationMiddleware(currentState: navigatorState).call(store,
+          NavigateToAction.pushNamedAndRemoveUntil('name', predicate), (_) {});
 
       verifyNever(navigatorState.pushNamed(any));
       verifyNever(navigatorState.pushReplacementNamed(any));
       verifyNever(navigatorState.pop());
+      verifyNever(navigatorState.popUntil(any));
       verify(navigatorState.pushNamedAndRemoveUntil('name', predicate));
+    });
+
+    test('should call popUntil on currentState', () {
+      final store = MockStore();
+      final navigatorState = MockNavigatorState();
+      final predicate = (Route<dynamic> route) => false;
+
+      NavigationMiddleware(currentState: navigatorState)
+          .call(store, NavigateToAction.popUntil(predicate: predicate), (_) {});
+
+      verifyNever(navigatorState.pushNamed(any));
+      verifyNever(navigatorState.pushReplacementNamed(any));
+      verifyNever(navigatorState.pop());
+      verifyNever(navigatorState.pushNamedAndRemoveUntil(any, any));
+      verify(navigatorState.popUntil(predicate));
     });
   });
 
@@ -140,12 +160,12 @@ void main() {
       final log = [];
 
       when(navigatorState.pushNamed('/name'))
-        .thenAnswer((_) async => log.add('/name'));
+          .thenAnswer((_) async => log.add('/name'));
 
       NavigationMiddleware(currentState: navigatorState).call(
-        store,
-        NavigateToAction.push('/name',
-          preNavigation: () => log.add('preNavigation')),
+          store,
+          NavigateToAction.push('/name',
+              preNavigation: () => log.add('preNavigation')),
           (_) {});
 
       expect(log, ['preNavigation', '/name']);
@@ -157,12 +177,12 @@ void main() {
       final log = [];
 
       when(navigatorState.pushNamed('/name'))
-        .thenAnswer((_) async => log.add('/name'));
+          .thenAnswer((_) async => log.add('/name'));
 
       NavigationMiddleware(currentState: navigatorState).call(
-        store,
-        NavigateToAction.push('/name',
-          postNavigation: () => log.add('postNavigation')),
+          store,
+          NavigateToAction.push('/name',
+              postNavigation: () => log.add('postNavigation')),
           (_) {});
 
       expect(log, ['/name', 'postNavigation']);
@@ -170,80 +190,80 @@ void main() {
 
     test('should call both pre and post hooks around the actual navigation',
         () {
-        final store = MockStore();
-        final navigatorState = MockNavigatorState();
-        final log = [];
+      final store = MockStore();
+      final navigatorState = MockNavigatorState();
+      final log = [];
 
-        when(navigatorState.pushNamed('/name'))
+      when(navigatorState.pushNamed('/name'))
           .thenAnswer((_) async => log.add('/name'));
 
-        NavigationMiddleware(currentState: navigatorState).call(
+      NavigationMiddleware(currentState: navigatorState).call(
           store,
           NavigateToAction.push(
             '/name',
             preNavigation: () => log.add('preNavigation'),
             postNavigation: () => log.add('postNavigation'),
           ),
-            (_) {});
+          (_) {});
 
-        expect(log, ['preNavigation', '/name', 'postNavigation']);
-      });
+      expect(log, ['preNavigation', '/name', 'postNavigation']);
+    });
   });
 
   group('state', () {
     test(
-      'should start by keeping only the currentPath in the state on initial push transition',
+        'should start by keeping only the currentPath in the state on initial push transition',
         () {
-        final store = MockStore();
-        final navigatorState = MockNavigatorState();
+      final store = MockStore();
+      final navigatorState = MockNavigatorState();
 
-        NavigationMiddleware(currentState: navigatorState)
+      NavigationMiddleware(currentState: navigatorState)
           .call(store, NavigateToAction.push('/name'), (_) {});
 
-        expect(NavigatorHolder.state.currentPath, '/name');
-        expect(NavigatorHolder.state.previousPath, isNull);
-      });
+      expect(NavigatorHolder.state.currentPath, '/name');
+      expect(NavigatorHolder.state.previousPath, isNull);
+    });
 
     test(
-      'should start by keeping only the currentPath in the state on initial replace transition',
+        'should start by keeping only the currentPath in the state on initial replace transition',
         () {
-        final store = MockStore();
-        final navigatorState = MockNavigatorState();
+      final store = MockStore();
+      final navigatorState = MockNavigatorState();
 
-        NavigationMiddleware(currentState: navigatorState)
+      NavigationMiddleware(currentState: navigatorState)
           .call(store, NavigateToAction.replace('/name'), (_) {});
 
-        expect(NavigatorHolder.state.currentPath, '/name');
-        expect(NavigatorHolder.state.previousPath, isNull);
-      });
+      expect(NavigatorHolder.state.currentPath, '/name');
+      expect(NavigatorHolder.state.previousPath, isNull);
+    });
 
     test(
-      'should store currentPath as the previousPath on every push transition',
+        'should store currentPath as the previousPath on every push transition',
         () {
-        final store = MockStore();
-        final navigatorState = MockNavigatorState();
-        final middleware = NavigationMiddleware(currentState: navigatorState);
+      final store = MockStore();
+      final navigatorState = MockNavigatorState();
+      final middleware = NavigationMiddleware(currentState: navigatorState);
 
-        middleware.call(store, NavigateToAction.push('/first'), (_) {});
-        middleware.call(store, NavigateToAction.push('/second'), (_) {});
+      middleware.call(store, NavigateToAction.push('/first'), (_) {});
+      middleware.call(store, NavigateToAction.push('/second'), (_) {});
 
-        expect(NavigatorHolder.state.currentPath, '/second');
-        expect(NavigatorHolder.state.previousPath, '/first');
-      });
+      expect(NavigatorHolder.state.currentPath, '/second');
+      expect(NavigatorHolder.state.previousPath, '/first');
+    });
 
     test(
-      'should store currentPath as the previousPath on every replace transition',
+        'should store currentPath as the previousPath on every replace transition',
         () {
-        final store = MockStore();
-        final navigatorState = MockNavigatorState();
-        final middleware = NavigationMiddleware(currentState: navigatorState);
+      final store = MockStore();
+      final navigatorState = MockNavigatorState();
+      final middleware = NavigationMiddleware(currentState: navigatorState);
 
-        middleware.call(store, NavigateToAction.replace('/first'), (_) {});
-        middleware.call(store, NavigateToAction.replace('/second'), (_) {});
+      middleware.call(store, NavigateToAction.replace('/first'), (_) {});
+      middleware.call(store, NavigateToAction.replace('/second'), (_) {});
 
-        expect(NavigatorHolder.state.currentPath, '/second');
-        expect(NavigatorHolder.state.previousPath, '/first');
-      });
+      expect(NavigatorHolder.state.currentPath, '/second');
+      expect(NavigatorHolder.state.previousPath, '/first');
+    });
 
     test('should reverse the path order on every pop transition', () {
       final store = MockStore();
@@ -267,6 +287,35 @@ void main() {
 
       expect(NavigatorHolder.state.currentPath, isNull);
       expect(NavigatorHolder.state.previousPath, isNull);
+    });
+
+    test('should keep initial state when initial navigation is popped until',
+        () {
+      final store = MockStore();
+      final navigatorState = MockNavigatorState();
+      final middleware = NavigationMiddleware(currentState: navigatorState);
+
+      middleware.call(
+          store, NavigateToAction.popUntil(predicate: (_) => false), (_) {});
+
+      expect(NavigatorHolder.state.currentPath, isNull);
+      expect(NavigatorHolder.state.previousPath, isNull);
+    });
+
+    test(
+        'should report current path as null and previous path correctly when all navigations are popped',
+        () {
+      final store = MockStore();
+      final navigatorState = MockNavigatorState();
+      final middleware = NavigationMiddleware(currentState: navigatorState);
+
+      middleware.call(store, NavigateToAction.push('/first'), (_) {});
+      middleware.call(store, NavigateToAction.push('/second'), (_) {});
+      middleware.call(
+          store, NavigateToAction.popUntil(predicate: (_) => false), (_) {});
+
+      expect(NavigatorHolder.state.currentPath, isNull);
+      expect(NavigatorHolder.state.previousPath, '/second');
     });
   });
 }


### PR DESCRIPTION
Hi, I've re-implemented pull request #10 and did the following:

- Implemented the popUntil action
- Added and updated tests
- Ran ```flutter format``` on the files that I modified.

The one thing I'm not happy with is how to update NavigationState to the current path, based on what that is once NavigatorState.popUntil(predicate) is finished. I wasn't able to find a way to get the current path from NavigatorState, and it seems the only way to do this is to implement popUntil manually and track the path changes.

I'm submitting this to ask for your opinion: do you think there's a better way to work around this?

Thanks!