### PR TITLE
Add alias so NavigationDestination does not break

### DIFF
--- a/lib/src/navigation_middleware.dart
+++ b/lib/src/navigation_middleware.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_redux_navigation/src/navigate_to_action.dart';
 import 'package:flutter_redux_navigation/src/navigation_destination.dart';
 import 'package:flutter_redux_navigation/src/navigation_holder.dart';


### PR DESCRIPTION
After upgrading flutter to 2.8.0, this ibrary started to break:

```gradle
Running Gradle task 'assembleDebug'...
../../../flutter/.pub-cache/hosted/pub.dartlang.org/flutter_redux_navigation-0.7.0/lib/src/navigation_middleware.dart:3:1: Error: 'NavigationDestination' is imported from both 'package:flutter/src/material/navigation_bar.dart' and 'package:flutter_redux_navigation/src/navigation_destination.dart'.
import 'package:flutter_redux_navigation/src/navigation_destination.dart';
^^^^^^^^^^^^^^^^^^^^^
../../../flutter/.pub-cache/hosted/pub.dartlang.org/flutter_redux_navigation-0.7.0/lib/src/navigation_middleware.dart:35:26: Error: 'NavigationDestination' is imported from both 'package:flutter/src/material/navigation_bar.dart' and 'package:flutter_redux_navigation/src/navigation_destination.dart'.
          this._setState(NavigationDestination(
                         ^^^^^^^^^^^^^^^^^^^^^
../../../flutter/.pub-cache/hosted/pub.dartlang.org/flutter_redux_navigation-0.7.0/lib/src/navigation_middleware.dart:55:26: Error: 'NavigationDestination' is imported from both 'package:flutter/src/material/navigation_bar.dart' and 'package:flutter_redux_navigation/src/navigation_destination.dart'.
          this._setState(NavigationDestination(
                         ^^^^^^^^^^^^^^^^^^^^^


FAILURE: Build failed with an exception.
```

In this new Flutter release, a new NavigationDestination widget was added, thus conflicting with the Flutter Redux Nav one. Adding an alias in the import solves the problem.